### PR TITLE
Added link to Asus Zenfone 2 Laser (Z00L/Z00T)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ Asus Zenfone 2 ZE551ML
 
 - https://github.com/pelya/android-keyboard-gadget/blob/master/asus-Zenfone-2-ZE551ML/boot.img?raw=true
 
+Asus Zenfone 2 Laser (Z00L/Z00T)
+----------------------
+
+- https://forum.xda-developers.com/zenfone-2-laser/development/kernel-firekernel-t3703326
+
 Sony Xperia Z5 Premium E6853
 ----------------------------
 


### PR DESCRIPTION
FireKernel supports android-keyboard-gadget functionality. Here is the kernel source https://github.com/Fire-Kernel/android_kernel_asus_msm8916 and here is the commit which added support for it https://github.com/Fire-Kernel/android_kernel_asus_msm8916/commit/8ef7577d42361efe8c46288eda2fc33b445950b6 and here is the commit enabling them https://github.com/Fire-Kernel/android_kernel_asus_msm8916/commit/fd95fdd8c5c9e4a77126f38ecaecf44eb5444656 .