### PR TITLE
Patch is not required for Kernel version > 3.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Convert your Android device into USB keyboard/mouse, control your PC from your Android device remotely, including BIOS/bootloader.
 
+For newer Kernel versions (>= 3.19) the patch is not anymore required and can be replaced by ConfigFS ([USB Gadget Tool](https://github.com/tejado/android-usb-gadget)).
+
 #### Apps & tools using android-keyboard-gadget:
 * [USB Keyboard](https://play.google.com/store/apps/details?id=remote.hid.keyboard.client)
 * hid-gadget-test


### PR DESCRIPTION
Hi pelya,

I'm the developer of Authorizer and released a new app for newer Android versions which makes the kernel patch obsolete:
Have a look here: https://github.com/tejado/android-usb-gadget

You need root and a newer kernel version (everything newer than 3.19 should work).
So maybe you don't mind to add that note in your README. Let me know if I should change the text.