### PR TITLE
Corrected keyboard format in How it works section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ You can open these two files, using open() system call,
 and write raw keyboard/mouse events there, using write() system call,
 which will be sent through USB cable to your PC.
 
+A short description of the events format is provided below. For a more comprehensive overview see the [OS Dev Wiki](https://wiki.osdev.org/USB_Human_Interface_Devices#USB_keyboard).
+
 Keyboard events
 ---------------
 Keyboard events are 8 bytes long:

--- a/README.md
+++ b/README.md
@@ -374,7 +374,16 @@ You can open these two files, using open() system call,
 and write raw keyboard/mouse events there, using write() system call,
 which will be sent through USB cable to your PC.
 
-Keyboard event is an array of 8 byte length, first byte is a bitmask of currently pressed modifier keys:
+Keyboard events
+---------------
+Keyboard events are 8 bytes long:
+| Offset | Length | Field |
+| --- | --- | --- |
+| 0 | 1 byte | Modifier keys bitmask |
+| 1 | 1 byte | Reserved padding |
+| 2 | 6 bytes | Pressed keys in the order they were pressed in |
+_______________________________________________________________
+First byte is a bitmask of currently pressed modifier keys:
 
 	typedef enum {
 		LCTRL = 0x1,
@@ -386,16 +395,22 @@ Keyboard event is an array of 8 byte length, first byte is a bitmask of currentl
 		RALT = 0x40,
 		RSUPER = 0x80, // Windows key
 	} ModifierKeys_t;
+_______________________________________________________________
+The second byte is reserved and usually ignored by software.
+_______________________________________________________________
+Remaining 6 bytes are a list of all other keys currently pressed, one byte for one key, or 0 if no key is pressed.
+A handy table with key scancodes can be found [here](https://www.win.tue.nl/~aeb/linux/kbd/scancodes-14.html).
 
-Remaining 7 bytes is a list of all other keys currently pressed, one byte for one key, or 0 if no key is pressed.
-Consequently, the maximum amount of keys that may be pressed at the same time is 7, excluding modifier keys.
-
-Professional or 'gamer' USB keyboards report several keyboard HID descriptors, which creates several keyboard devices in host PC,
-to overcome that 7-key limit.
-
-The scancode table for each key is available [in hid-gadget-test utility](hid-gadget-test/jni/hid-gadget-test.c#L33).
 Extended keys, such as Play/Pause, are not supported, because they require modifying USB descriptor in kernel patch.
 
+Consequently, the maximum amount of keys that may be pressed at the same time is 6, excluding modifier keys.
+Professional or 'gamer' USB keyboards report several keyboard HID descriptors, which creates several keyboard devices in host PC,
+to overcome that 6-key limit.
+
+Note that after writing an event the keys will be held indefinitely, so when finished an empty event should be sent to release all keys.
+
+Mouse events
+------------
 Mouse event is an array of 4 bytes, first byte is a bitmask of currently pressed mouse buttons:
 
 	typedef enum {


### PR DESCRIPTION
In the 'How it works' section the keyboard event format did not imply that the second byte is reserved. This probably led to a user having problems described in [this issue](https://github.com/pelya/android-keyboard-gadget/issues/35).

I added this information in a table form and corrected the maximum number of simultaneously pressed keys from 7 to 6. The amount of 6 keys is confirmed by [this Wikipedia article](https://en.wikipedia.org/wiki/USB_human_interface_device_class#Keyboards) and by [the osdev link I added](https://wiki.osdev.org/USB_Human_Interface_Devices#USB_keyboard).

I also changed the reference from the hid-gadget-test source code to a more useful table and added a handy link to the osdev wiki about USB HID.